### PR TITLE
Gitlab integration improvements

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ var rootCmd = &cobra.Command{
 		case "github":
 			client = github.NewGitHubClient(cfg.Token)
 		case "gitlab":
-			client = gitlab.NewGitlabClient(cfg.Token, cfg.Server)
+			client = gitlab.NewGitlabClient(cfg.Server, cfg.Token)
 		case "bitbucket":
 			client = bitbucket.NewBitbucketClient(cfg.Username, cfg.Token)
 		case "forgejo":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ var rootCmd = &cobra.Command{
 		case "github":
 			client = github.NewGitHubClient(cfg.Token)
 		case "gitlab":
-			client = gitlab.NewGitlabClient(cfg.Token)
+			client = gitlab.NewGitlabClient(cfg.Token, cfg.Server)
 		case "bitbucket":
 			client = bitbucket.NewBitbucketClient(cfg.Username, cfg.Token)
 		case "forgejo":

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -15,7 +15,7 @@ type GitlabClient struct {
 	Client *gl.Client
 }
 
-func NewGitlabClient(token string, serverConfig config.Server) *GitlabClient {
+func NewGitlabClient(serverConfig config.Server, token string) *GitlabClient {
 	baseURL := fmt.Sprintf("%s://%s/api/v4", serverConfig.Protocol, serverConfig.Domain)
 	client, err := gl.NewClient(token, gl.WithBaseURL(baseURL))
 	if err != nil {
@@ -62,7 +62,7 @@ func (c GitlabClient) getProjects(cfg config.Config) ([]*gl.Project, error) {
 		ListOptions: gl.ListOptions{
 			OrderBy:    "id",
 			Pagination: "keyset",
-			PerPage:    10,
+			PerPage:    100,
 			Sort:       "asc",
 		},
 		Owned: &[]bool{true}[0],


### PR DESCRIPTION
- Support self-hosted instances by setting the API base url in the client during initialization
- Update getProjects method to use pagination while querying the ListProjects API to ensure all repos for the user are synced

Pagination code is based on example from go-gitlab library: https://github.com/xanzy/go-gitlab/blob/main/examples/pagination.go#L60

## Testing details

### Self-hosted gitlab instance

When I set the `server.domain` do my self-hosted gitlab instance, I get a 401 error and the error message specifically mentions the main gitlab instance API endpoint (`https://gitlab.com/api/v4/projects`) not the one from my self-hosted instance.

```
{"level":"fatal","time":"2024-09-29T03:16:46.494Z","message":"Error syncing repositories: GET https://gitlab.com/api/v4/projects: 401 {message: 401 Unauthorized}","stacktrace":"github.com/AkashRajpurohit/git-sync/pkg/logger.Fatalf\n\t/go/src/app/pkg/logger/logger.go:96\ngithub.com/AkashRajp
urohit/git-sync/cmd.init.func1\n\t/go/src/app/cmd/root.go:120\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117\ngithub.com/spf13/cobra.(*Command).Execute\n
\t/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041\ngithub.com/AkashRajpurohit/git-sync/cmd.Execute\n\t/go/src/app/cmd/root.go:127\nmain.main\n\t/go/src/app/main.go:6\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:272"}
```

### Pagination

Without pagination changes, git-sync only finds 20 repos:

```
{"level":"info","time":"2024-09-29T03:21:39.188Z","message":"Total projects: 20"}
```

With the pagination changes it finds all of my projects

```
{"level":"info","time":"2024-09-29T02:57:36.793Z","message":"Total projects: 189"}
```