### PR TITLE
feat: :sparkles: allow different clone type options

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ var rootCmd = &cobra.Command{
 				Workspace:    "",
 				Cron:         "",
 				BackupDir:    config.GetBackupDir(backupDir),
+				CloneType:    "bare",
 			}
 
 			err = config.SaveConfig(cfg, cfgFile)
@@ -68,6 +69,11 @@ var rootCmd = &cobra.Command{
 		// If cron option is passed in the command line, use that instead of the one in the config file
 		if cron != "" {
 			cfg.Cron = cron
+		}
+
+		// If no clone_type is not set in the config file, set it to bare
+		if cfg.CloneType == "" {
+			cfg.CloneType = "bare"
 		}
 
 		logger.Info("Config loaded from: ", config.GetConfigFile(cfgFile))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	BackupDir    string   `mapstructure:"backup_dir"`
 	Workspace    string   `mapstructure:"workspace"`
 	Cron         string   `mapstructure:"cron"`
+	CloneType    string   `mapstructure:"clone_type"`
 }
 
 func expandPath(path string) string {
@@ -105,6 +106,7 @@ func SaveConfig(config Config, cfgFile string) error {
 	viper.Set("server", config.Server)
 	viper.Set("workspace", config.Workspace)
 	viper.Set("cron", config.Cron)
+	viper.Set("clone_type", config.CloneType)
 
 	return viper.WriteConfig()
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -38,5 +38,10 @@ func ValidateConfig(cfg Config) error {
 		}
 	}
 
+	// validate that clone_type can only be `bare`, `full`, `mirror` or `shallow`
+	if cfg.CloneType != "bare" && cfg.CloneType != "full" && cfg.CloneType != "mirror" && cfg.CloneType != "shallow" {
+		return fmt.Errorf("clone_type can only be `bare`, `full`, `mirror` or `shallow`")
+	}
+
 	return nil
 }


### PR DESCRIPTION
The idea is to allow user's to be able to pick what type of clone option they want to use while using git-sync for backups.

To maintain backward compatibility, the default clone option would be `bare` if none specified in the config file.