### PR TITLE
feat: :sparkles: use cache between docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ permissions:
   id-token: write
   discussions: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_IMAGE: ghcr.io/akashrajpurohit/git-sync
+
 jobs:
   test:
     name: Test
@@ -55,33 +62,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker_build_and_push:
-    name: Docker Build & Push
+  docker_build:
+    name: Docker Build
     runs-on: ubuntu-latest
-    needs: [test]
-
+    needs: 
+      - test
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          - linux/arm/v7
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set env
+      - name: Prepare
         run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "NOW=$(date --utc +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
+          images: ${{ env.REGISTRY_IMAGE }}
+      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -91,24 +99,68 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & push Docker image to ghcr.io
-        uses: docker/build-push-action@v4
+      
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
-          context: .
-          push: true
-          tags: |
-            - ghcr.io/${{ github.repository }}:${{ env.RELEASE_VERSION }}
-            - ghcr.io/${{ github.repository }}:latest
-          platforms: |
-            - linux/amd64
-            - linux/arm64
-            - linux/arm/v7
-          build-args: |
-            VERSION=${{ env.RELEASE_VERSION }}
-            BUILD_DATE=${{ env.NOW }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-      - name: Move new cache to old cache
-        run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  docker_merge:
+    name: Docker Merge and Push
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - docker_build
+    timeout-minutes: 15
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+      
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker_build:
-    name: Docker Build
+  docker_build_and_push:
+    name: Docker Build & Push
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker_push:
-    name: Docker Build & Push
+  docker_build:
+    name: Docker Build
     runs-on: ubuntu-latest
 
     steps:
@@ -51,15 +51,44 @@ jobs:
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "NOW=$(date --utc +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
 
-      - name: Build & push Docker image to ghcr.io
-        uses: mr-smithers-excellent/docker-build-push@v6
+      - name: Cache Docker layers
+        uses: actions/cache@v3
         with:
-          image: git-sync
-          tags: ${{ env.RELEASE_VERSION }},latest
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
           registry: ghcr.io
-          multiPlatform: true
-          platform: linux/amd64,linux/arm64,linux/arm/v7
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          buildArgs: 'VERSION=${{ env.RELEASE_VERSION }},BUILD=${{ env.NOW }}'
 
+      - name: Build & push Docker image to ghcr.io
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            - ghcr.io/${{ github.repository }}:${{ env.RELEASE_VERSION }}
+            - ghcr.io/${{ github.repository }}:latest
+          platforms: |
+            - linux/amd64
+            - linux/arm64
+            - linux/arm/v7
+          build-args: |
+            VERSION=${{ env.RELEASE_VERSION }}
+            BUILD_DATE=${{ env.NOW }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Move new cache to old cache
+        run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,6 @@ FROM alpine:latest
 WORKDIR /opt/go
 
 LABEL maintainer="AkashRajpurohit <me@akashrajpurohit.com>"
-LABEL org.opencontainers.image.authors="AkashRajpurohit <me@akashrajpurohit.com>"
-LABEL org.opencontainers.image.version="${VERSION}"
-LABEL org.opencontainers.image.build-date="${BUILD_DATE}"
-LABEL org.opencontainers.image.source="https://github.com/AkashRajpurohit/git-sync"
-LABEL org.opencontainers.image.title="git-sync"
-LABEL org.opencontainers.image.description="A tool to backup and sync your git repositories"
 
 # Install git since it's required for the application
 RUN apk update && \


### PR DESCRIPTION
Currently, each release have 2 steps, creating binary packages for different OS and arch and creating docker images for multi platforms.
The average duration for docker step takes 7-8 minutes.

This is majorly because it has to do all the layer computation again between releases. The of this PR is to leverage cache so that we can avoid layer computation for steps where nothing have changed.