### PR TITLE
fix: :bug: sync using origin remote by default

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -35,23 +35,23 @@ func getGitCloneCommand(CloneType, repoPath, repoURL string) *exec.Cmd {
 	}
 }
 
-func getGitFetchCommand(CloneType, repoPath string) *exec.Cmd {
+func getGitFetchCommand(CloneType, repoPath, repoURL string) *exec.Cmd {
 	switch CloneType {
 	case "bare":
 		logger.Debugf("Updating repo with bare clone type: %s", repoPath)
-		return exec.Command("git", "--git-dir", repoPath, "fetch", "--prune", "origin", "+*:*")
+		return exec.Command("git", "--git-dir", repoPath, "fetch", "--prune", repoURL, "+*:*")
 	case "full":
 		logger.Debugf("Updating repo with full clone type: %s", repoPath)
-		return exec.Command("git", "-C", repoPath, "pull", "--prune")
+		return exec.Command("git", "-C", repoPath, "pull", "--prune", repoURL)
 	case "mirror":
 		logger.Debugf("Updating repo with mirror clone type: %s", repoPath)
-		return exec.Command("git", "-C", repoPath, "fetch", "--prune", "origin", "+*:*")
+		return exec.Command("git", "-C", repoPath, "fetch", "--prune", repoURL, "+*:*")
 	case "shallow":
 		logger.Debugf("Updating repo with shallow clone type: %s", repoPath)
-		return exec.Command("git", "-C", repoPath, "pull", "--prune")
+		return exec.Command("git", "-C", repoPath, "pull", "--prune", repoURL)
 	default:
 		logger.Debugf("[Default] Updating repo with bare clone type: %s", repoPath)
-		return exec.Command("git", "--git-dir", repoPath, "fetch", "--prune", "origin", "+*:*")
+		return exec.Command("git", "--git-dir", repoPath, "fetch", "--prune", repoURL, "+*:*")
 	}
 }
 
@@ -73,7 +73,7 @@ func CloneOrUpdateRepo(repoOwner, repoName string, config config.Config) {
 		}
 	} else {
 		logger.Info("Updating repo: ", repoFullName)
-		command := getGitFetchCommand(config.CloneType, repoPath)
+		command := getGitFetchCommand(config.CloneType, repoPath, repoURL)
 
 		output, err := command.CombinedOutput()
 		logger.Debugf("Output: %s\n", output)


### PR DESCRIPTION
I believe this change should fix the errors related to tokens being expired or overall changes to the config not being used after the first clone.
Instead of relying explicitly or implicitly in the `origin` remote, I used the URL that we already combine every time as a parameter to the `<repository>` argument of the [fetch](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-ltrepositorygt) and [pull](https://git-scm.com/docs/git-pull#Documentation/git-pull.txt-ltrepositorygt) commands.
I tested this with a simple testcase that I created on purpose, if someone could please test this further (preferably with a real issue - the ones regarding the error code 128), that would be awesome.